### PR TITLE
Change print from statement to function in harmonisation_input_checker.py

### DIFF
--- a/src/main/tools/harmonisation_input_checker.py
+++ b/src/main/tools/harmonisation_input_checker.py
@@ -5,6 +5,8 @@ Usage:
 python harmonisation_input_checker.py path/to/matchup/file.nc
 """
 
+from __future__ import print_function
+
 '''___Python Modules___'''
 import sys
 
@@ -580,7 +582,7 @@ def main(path):
     :param path: path of harmonisation input file to
     """
 
-    print "Testing File:", path
+    print("Testing File:", path)
 
     # 1. Find any errors!
     rootgrp = Dataset(path)
@@ -600,12 +602,12 @@ def main(path):
     # 2. Report errors
 
     if errors == []:
-        print "Test Passed"
+        print("Test Passed")
     else:
-        print "The following errors have been detected:"
+        print("The following errors have been detected:")
         for error in errors:
-            print ">", error
-    print ""
+            print(">", error)
+    print("")
 
     return 0
 


### PR DESCRIPTION
This commit changes no functionality whatsoever, apart from making
harmonisation_input_checker.py support both Python 2 and Python 3.
It currently supports only Python 2.

Please confirm that it runs identically with Python 2 as before.