### PR TITLE
In harmonisation file checker, return error code when tests not passed

### DIFF
--- a/src/main/tools/harmonisation_input_checker.py
+++ b/src/main/tools/harmonisation_input_checker.py
@@ -609,7 +609,7 @@ def main(path):
             print(">", error)
     print("")
 
-    return 0
+    return len(errors)>0
 
 if __name__ == "__main__":
-    main(sys.argv[1])
+    sys.exit(main(sys.argv[1]))


### PR DESCRIPTION
Returning an error code makes this easier to use from a shell script.